### PR TITLE
Rewrite Makefile and fix logger_buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,30 @@
-CC = gcc
-LINKER = gcc
+LUA         = 5.1
+LUA_CFLAGS  = $(shell pkg-config --cflags lua$(LUA))
+LUA_LIBS    = $(shell pkg-config --libs lua$(LUA))
 
-LFLAGS = -Wall -I. -lrt -llua -lcurl -shared -fPIC
-CFLAGS = -Wall -lrt -llua -lcurl -shared -fPIC
+CFLAGS      = -Wall -fPIC -shared $(LUA_CFLAGS) -Isrc/
+LIBS        = -lrt -lcurl $(LUA_LIBS)
 
-SRCDIR = src
-OBJDIR = obj
-BINDIR = bin
+PREFIX      = /usr/local
+LIBDIR      = $(PREFIX)/lib/lua/$(LUA)
 
-SOURCES  := $(wildcard $(SRCDIR)/*.c)
-INCLUDES := $(wildcard $(SRCDIR)/*.h)
-OBJECTS  := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
-TARGET = lua_async_http.so
+SRC = src/libcurl_async.c src/libcurl_helpers.c src/libcurl_logger.c \
+	src/libcurl_lua.c src/libcurl_multi.c
+OBJ= $(SRC:.c=.o)
 
-$(BINDIR)/$(TARGET): $(OBJECTS)
-		@mkdir -p $(@D) 
-		$(LINKER) -o $@ $(LFLAGS) $(OBJECTS)
-		@echo "Linking complete!"
+all: lua_async_http.so
 
-$(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.c
-		@mkdir -p $(@D) 
-		$(CC) $(CFLAGS) -c $< -o $@
-		@echo "Compiled "$<" successfully!"
+lua_async_http.so: $(OBJ)
+	$(CC) $(CFLAGS) -shared -o $@ $(OBJ) $(LIBS)
 
 clean:
-	rm -f $(OBJDIR)/*.o $(OBJDIR)/*.so
+	rm -f src/*.o *.so
+
+install:
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m 755 lua_async_http.so $(DESTDIR)$(LIBDIR)/lua_async_http.so
+
+uninstall:
+	rm -f $(DESTDIR)$(LIBDIR)/lua_async_http.so
+
+.PHONY: lua_async_http.so

--- a/src/libcurl_async.h
+++ b/src/libcurl_async.h
@@ -67,7 +67,6 @@ typedef struct {
   size_t       count;                     /* request count                                              */
 } request_handler;
 
-char logger_buffer[LOGGER_BUFFER_SIZE];   /* the buffer used for logger messages                        */
 
 /* ============================================= FUNCTIONS ============================================= */
 

--- a/src/libcurl_logger.c
+++ b/src/libcurl_logger.c
@@ -1,6 +1,12 @@
 #include "libcurl_async.h"
 
 /**
+* the buffer used for logger messages
+* Fix multiple definition of `logger_buffer' on link library
+**/
+char logger_buffer[LOGGER_BUFFER_SIZE];
+
+/**
  * :print_log
  * basicaly prints the log message to the machine
  * console stderr. those message could monitored later on.


### PR DESCRIPTION
- Rewritten `Makefile` as the original `Makefile` does not link the library correctly and added `install` and `uninstall` instrucction
- Fix multiple definition of `logger_buffer` on link library